### PR TITLE
workaround for 'racket -e' namespace issue

### DIFF
--- a/out/enter.rkt
+++ b/out/enter.rkt
@@ -1,0 +1,8 @@
+; Using "racket -e ..." has a namespace issue,
+; see https://www.mail-archive.com/racket-users@googlegroups.com/msg39219.html
+; This is a workaround that uses "racket -f ..." instead as proposed here:
+; https://www.mail-archive.com/racket-users@googlegroups.com/msg39209.html
+(define args (current-command-line-arguments))
+(define dirname (vector-ref args 0))
+(define filename (vector-ref args 1))
+(dynamic-enter! (build-path dirname filename))

--- a/out/launch_windows.bat
+++ b/out/launch_windows.bat
@@ -1,0 +1,2 @@
+cd %1
+racket -i -f "%~dp0/enter.rkt" "%1" "%2"

--- a/src/replManager.ts
+++ b/src/replManager.ts
@@ -74,7 +74,7 @@ export class REPLManager implements vscode.Disposable {
     private launch(dir: String, file: String) {
         var launcher: String;
         switch (os_type) {
-            case 'win32': launcher = 'launch_windows.exe'; break;
+            case 'win32': launcher = 'launch_windows.bat'; break;
             case 'linux': launcher = 'launch_linux'; break;
             case 'darwin': launcher = 'launch_mac'; break;
             default: {


### PR DESCRIPTION
Fix a namespace issue. For example, if you have `(define x 1)` in your code, you want `x` to be available on the REPL.

This no longer attempts to clear the console so you might not want to merge it. (On the other hand, I generally prefer to see what my scripts are doing; it makes it easier to figure out when something goes wrong.)