### PR TITLE
Fix terminal focus

### DIFF
--- a/src/replManager.ts
+++ b/src/replManager.ts
@@ -33,7 +33,7 @@ export class REPLManager implements vscode.Disposable {
         this.launch(dir, file);
 
         //Focus terminal.
-        this._terminal.show(true);
+        this._terminal.show(false);
     }
 
     //Stops the REPL in the given terminal (defaults to running terminal).


### PR DESCRIPTION
Terminal.show() treats `true` as 'preserve focus',
  so instead, to switch the focus to terminal, we need to pass `false`

Reference: https://code.visualstudio.com/api/references/vscode-api#Terminal