### PR TITLE
Enable run shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
         }
       }
     ],
+    "keybindings": [
+      {
+        "command": "racket-repl.run",
+        "key": "ctrl+r ctrl+r",
+        "mac": "cmd+r cmd+r",
+        "when": "editorTextFocus && editorLangId == racket"
+      }
+    ],
     "languages": [
       {
         "id": "racket",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,11 +9,13 @@ export function activate(context: vscode.ExtensionContext) {
 	const manager = new REPLManager();
 
 	//Register run command
-	let run = vscode.commands.registerCommand('racket-repl.run', (fileUri) => {
+	let run = vscode.commands.registerTextEditorCommand('racket-repl.run', (editor: vscode.TextEditor) => {
+		const filepath: String = editor.document.fileName;
+
 		//Start REPL
-		manager.run(fileUri);
+		manager.run(filepath);
 		// Display a message box to the user containing the filename.
-		vscode.window.showInformationMessage('Running: ' + fileUri.path.substr(fileUri.path.lastIndexOf('/') + 1));
+		vscode.window.showInformationMessage('Running: ' + filepath.substr(filepath.lastIndexOf('/') + 1));
 	});
 
 	//Register stop command

--- a/src/replManager.ts
+++ b/src/replManager.ts
@@ -17,7 +17,7 @@ export class REPLManager implements vscode.Disposable {
     }
 
     //Runs the REPL using the current file.
-    public async run(fileUri: vscode.Uri) {
+    public async run(filepath: String) {
 
         //Always run in a new terminal (I found no other way to close the Racket shell)
         //Stop the old terminal
@@ -25,9 +25,9 @@ export class REPLManager implements vscode.Disposable {
         //Create a new terminal
         this._terminal = this.init_terminal();
 
-        var dir: String = fileUri.path.substring(0, fileUri.path.lastIndexOf("/"));
+        var dir: String = filepath.substring(0, filepath.lastIndexOf("/"));
         dir = this.formatPath(dir);
-        const file: String = fileUri.path.substring(fileUri.path.lastIndexOf("/") + 1);
+        const file: String = filepath.substring(filepath.lastIndexOf("/") + 1);
 
         //Start the REPL.
         this.launch(dir, file);


### PR DESCRIPTION
Bind `racket-repl.run` to `ctrl+r ctrl+r`.
Old behaviour is preserved: buttons are functioning as before.

The biggest change is around `registerCommand` -> `registerTextEditorCommand`
  because formal did not recieve filepath when invoked with shortcut,
  while latter accepts `textEditor` as input.